### PR TITLE
feat: implement Fast-SNP, speed up loopless FVA

### DIFF
--- a/src/cobra/flux_analysis/__init__.py
+++ b/src/cobra/flux_analysis/__init__.py
@@ -7,6 +7,7 @@ from .deletion import (
     single_reaction_deletion,
 )
 from .fastcc import fastcc
+from .find_cyclic_reactions import find_cyclic_reactions
 from .gapfilling import gapfill
 from .geometric import geometric_fba
 from .loopless import loopless_solution, add_loopless

--- a/src/cobra/flux_analysis/find_cyclic_reactions.py
+++ b/src/cobra/flux_analysis/find_cyclic_reactions.py
@@ -57,7 +57,7 @@ def find_cyclic_reactions(
     zero_cutoff: Optional[float] = None,
     bound: float = 1e4,
     method: str = "optimized",
-    required_stop_checks_num: int = 2,
+    required_stop_checks_num: int = 3,
 ) -> Tuple[List[str], List[Tuple[bool, bool]]]:
     """Find all reactions, that can be in a loop in a steady state flux distribution.
 
@@ -78,7 +78,7 @@ def find_cyclic_reactions(
     required_stop_checks_num : int, optional
         This parameter is used only for the "optimized" method.
         The number of random checks to pass to prove that all cyclic
-        reactions were found. (default is 2).
+        reactions were found. (default is 3).
 
     Returns
     -------

--- a/src/cobra/flux_analysis/find_cyclic_reactions.py
+++ b/src/cobra/flux_analysis/find_cyclic_reactions.py
@@ -1,12 +1,13 @@
-from typing import TYPE_CHECKING, Optional, List, Tuple
+"""Provides a function to find cyclic reactions in a metabolic model."""
 
-import time
+from typing import TYPE_CHECKING, List, Optional, Tuple
+
 import numpy as np
 import optlang
 from optlang.symbolics import Zero
 
-from ..util import solver as sutil
 from ..util import create_stoichiometric_matrix
+from ..util import solver as sutil
 from .helpers import normalize_cutoff
 
 
@@ -19,17 +20,17 @@ def _create_find_cyclic_reactions_problem(
     s_int: np.ndarray,
     directions_int: np.ndarray,
     zero_cutoff: float,
-    bound: float
+    bound: float,
 ) -> Tuple["optlang.interface.Model", List["optlang.interface.Variable"]]:
     model = solver.Model()
-    
+
     q_list = []
     for i in range(s_int.shape[1]):
         q = solver.Variable(
-            name=f'q_{i}',
-            lb=bound*min(0, directions_int[i, 0]),
-            ub=bound*max(0, directions_int[i, 1]),
-            problem=model
+            name=f"q_{i}",
+            lb=bound * min(0, directions_int[i, 0]),
+            ub=bound * max(0, directions_int[i, 1]),
+            problem=model,
         )
         q_list.append(q)
     model.add(q_list)
@@ -38,15 +39,13 @@ def _create_find_cyclic_reactions_problem(
         nnz_list = np.flatnonzero(np.abs(row) > zero_cutoff)
         if len(nnz_list) == 0:
             continue
-        constraint = solver.Constraint(
-            Zero,
-            lb=0.0,
-            ub=0.0,
-            problem=model,
-            name=f'row_{idx}'
-        )
+        constraint = solver.Constraint(Zero, lb=0, ub=0, name=f"row_{idx}")
         model.add([constraint], sloppy=True)
-        constraint.set_linear_coefficients({q_list[i]: row[i] for i in nnz_list})
+        model.constraints[f"row_{idx}"].set_linear_coefficients(
+            {q_list[i]: row[i] for i in nnz_list}
+        )
+
+    model.update()
 
     model.objective = solver.Objective(Zero)
 
@@ -58,11 +57,54 @@ def find_cyclic_reactions(
     zero_cutoff: Optional[float] = None,
     bound: float = 1e4,
     method: str = "optimized",
-    required_stop_random_checks_num: int = 2
-) -> List[str]:
+    required_stop_checks_num: int = 2,
+) -> Tuple[List[str], List[Tuple[bool, bool]]]:
+    """Find all reactions, that can be in a loop in a steady state flux distribution.
+
+    Parameters
+    ----------
+    model : cobra.Model
+        The metabolic model to analyze.
+    zero_cutoff : float, optional
+        The cutoff value to consider a flux as zero.
+        The default uses the `model.tolerance` (default None).
+    bound : float, optional
+        The bound for the reaction fluxes in the optimization problem.
+        (default is 1e4).
+    method : str, optional
+        The method to use for finding cyclic reactions.
+        Options are "optimized" (default) or "basic".
+        See notes for details.
+    required_stop_checks_num : int, optional
+        This parameter is used only for the "optimized" method.
+        The number of random checks to pass to prove that all cyclic
+        reactions were found. (default is 2).
+
+    Returns
+    -------
+    A tuple containing two lists:
+        - A list of reaction IDs that can be part of a loop.
+        - A list of tuples indicating the possible directions of
+          reactions from the first list in the loop.
+          Each tuple contains two boolean values: (can_be_negative, can_be_positive).
+
+    Notes
+    -----
+    The "basic" method for each reaction and direction checks if it can be a part of
+    a loop by optimizing linear programming problem.
+
+    The "optimized" method uses a faster randomized approach to firstly find all
+    reactions that can be part of a loop and then checks their directions. This method
+    usually works at least 2 times faster than the "basic" method.
+    The `required_stop_checks_num` parameter is used to descrease the probability
+    of missing some cyclic reactions.
     """
-        TODO: @isaf27
-    """
+
+    if required_stop_checks_num < 1:
+        raise ValueError(
+            "The `required_stop_checks_num` parameter must be greater than 0."
+        )
+
     zero_cutoff = normalize_cutoff(model, zero_cutoff)
 
     internal = [i for i, r in enumerate(model.reactions) if not r.boundary]
@@ -73,11 +115,7 @@ def find_cyclic_reactions(
     directions_int = np.sign(bounds_int)
 
     lp, q_list = _create_find_cyclic_reactions_problem(
-        model.problem,
-        s_int,
-        directions_int,
-        zero_cutoff,
-        bound
+        model.problem, s_int, directions_int, zero_cutoff, bound
     )
 
     candidate_reactions = list(range(n))
@@ -88,15 +126,18 @@ def find_cyclic_reactions(
         is_cyclic = [False] * n
 
         def set_reaction_weights():
-            weights = np.random.uniform(0.5, 1.0, size=n) * (2 * np.random.randint(low=0, high=2, size=n) - 1)
-            lp.objective.set_linear_coefficients({q_list[i]: weights[i] for i in range(n) if not is_cyclic[i]})
+            signs = 2 * np.random.randint(low=0, high=2, size=n) - 1
+            weights = np.random.uniform(0.5, 1.0, size=n) * signs
+            lp.objective.set_linear_coefficients(
+                {q_list[i]: weights[i] for i in range(n) if not is_cyclic[i]}
+            )
 
         set_reaction_weights()
         dir_order = ["min", "max"]
-        current_stop_random_checks_num = 0
+        stop_checks_num = 0
         cyclic_reactions_num = 0
 
-        while cyclic_reactions_num < n and current_stop_random_checks_num < required_stop_random_checks_num:
+        while cyclic_reactions_num < n and stop_checks_num < required_stop_checks_num:
             found_cyclic = False
             reverse_dir_order = False
 
@@ -120,14 +161,14 @@ def find_cyclic_reactions(
 
                     found_cyclic = True
                     lp.objective.set_linear_coefficients(remove_coef)
-                    current_stop_random_checks_num = 0
+                    stop_checks_num = 0
                     break
 
                 reverse_dir_order = True
 
             if not found_cyclic:
                 set_reaction_weights()
-                current_stop_random_checks_num += 1
+                stop_checks_num += 1
 
             if reverse_dir_order:
                 dir_order.reverse()
@@ -143,7 +184,9 @@ def find_cyclic_reactions(
             if directions_int[i, int(dir == "max")] == 0:
                 continue
 
-            lp.objective.set_linear_coefficients({q_list[i]: 1.0 if dir == "max" else -1.0})
+            lp.objective.set_linear_coefficients(
+                {q_list[i]: 1.0 if dir == "max" else -1.0}
+            )
 
             lp.optimize()
             sutil.check_solver_status(lp.status)
@@ -156,7 +199,11 @@ def find_cyclic_reactions(
 
         lp.objective.set_linear_coefficients({q_list[i]: 0.0})
 
-    cyclic_reactions = [model.reactions[internal[i]].id for i in range(n) if can_positive[i] or can_negative[i]]
-    cyclic_reactions_directions = [(can_negative[i], can_positive[i]) for i in range(n) if can_negative[i] or can_positive[i]]
+    cyclic_reactions = []
+    cyclic_reactions_directions = []
+    for i in range(n):
+        if can_positive[i] or can_negative[i]:
+            cyclic_reactions.append(model.reactions[internal[i]].id)
+            cyclic_reactions_directions.append((can_negative[i], can_positive[i]))
 
     return cyclic_reactions, cyclic_reactions_directions

--- a/src/cobra/flux_analysis/find_cyclic_reactions.py
+++ b/src/cobra/flux_analysis/find_cyclic_reactions.py
@@ -100,6 +100,11 @@ def find_cyclic_reactions(
     of missing some cyclic reactions.
     """
 
+    if method not in ["optimized", "basic"]:
+        raise ValueError(
+            "The `method` parameter must be either 'optimized' or 'basic'."
+        )
+
     if required_stop_checks_num < 1:
         raise ValueError(
             "The `required_stop_checks_num` parameter must be greater than 0."

--- a/src/cobra/flux_analysis/find_cyclic_reactions.py
+++ b/src/cobra/flux_analysis/find_cyclic_reactions.py
@@ -57,7 +57,8 @@ def find_cyclic_reactions(
     model: "Model",
     zero_cutoff: Optional[float] = None,
     bound: float = 1e4,
-    method: str = "optimized"
+    method: str = "optimized",
+    required_stop_random_checks_num: int = 2
 ) -> List[str]:
     """
         TODO: @isaf27
@@ -84,22 +85,19 @@ def find_cyclic_reactions(
     can_negative = [False] * n
 
     if method == "optimized":
-        is_active = [False] * n
+        is_cyclic = [False] * n
 
-        random_checks_left_count = 3
-        def set_random_weights():
-            nonlocal random_checks_left_count
-            random_checks_left_count -= 1
-            
+        def set_reaction_weights():
             weights = np.random.uniform(0.5, 1.0, size=n) * (2 * np.random.randint(low=0, high=2, size=n) - 1)
-            weights /= np.sum(np.abs(weights))
-            lp.objective.set_linear_coefficients({q_list[i]: weights[i] for i in range(n) if not is_active[i]})
+            lp.objective.set_linear_coefficients({q_list[i]: weights[i] for i in range(n) if not is_cyclic[i]})
 
-        set_random_weights()
+        set_reaction_weights()
         dir_order = ["min", "max"]
+        current_stop_random_checks_num = 0
+        cyclic_reactions_num = 0
 
-        while True:
-            found_active = False
+        while cyclic_reactions_num < n and current_stop_random_checks_num < required_stop_random_checks_num:
+            found_cyclic = False
             reverse_dir_order = False
 
             for dir in dir_order:
@@ -111,30 +109,30 @@ def find_cyclic_reactions(
                 if abs(lp.objective.value) > zero_cutoff:
                     remove_coef = {}
                     for i in range(n):
-                        if not is_active[i] and abs(q_list[i].primal) > zero_cutoff:
-                            is_active[i] = True
+                        if not is_cyclic[i] and abs(q_list[i].primal) > zero_cutoff:
+                            is_cyclic[i] = True
+                            cyclic_reactions_num += 1
                             remove_coef[q_list[i]] = 0
                             if q_list[i].primal > zero_cutoff:
                                 can_positive[i] = True
                             else:
                                 can_negative[i] = True
 
-                    found_active = True
+                    found_cyclic = True
                     lp.objective.set_linear_coefficients(remove_coef)
+                    current_stop_random_checks_num = 0
                     break
 
                 reverse_dir_order = True
 
-            if not found_active:
-                if random_checks_left_count > 0:
-                    set_random_weights()
-                    continue
-                break
+            if not found_cyclic:
+                set_reaction_weights()
+                current_stop_random_checks_num += 1
 
             if reverse_dir_order:
                 dir_order.reverse()
 
-        candidate_reactions = [i for i in range(n) if is_active[i]]
+        candidate_reactions = [i for i in range(n) if is_cyclic[i]]
 
     lp.objective = model.problem.Objective(Zero, direction="max")
     for i in candidate_reactions:
@@ -159,6 +157,6 @@ def find_cyclic_reactions(
         lp.objective.set_linear_coefficients({q_list[i]: 0.0})
 
     cyclic_reactions = [model.reactions[internal[i]].id for i in range(n) if can_positive[i] or can_negative[i]]
-    cyclic_reactions_directions = [(can_positive[i], can_negative[i]) for i in range(n) if can_positive[i] or can_negative[i]]
+    cyclic_reactions_directions = [(can_negative[i], can_positive[i]) for i in range(n) if can_negative[i] or can_positive[i]]
 
     return cyclic_reactions, cyclic_reactions_directions

--- a/src/cobra/flux_analysis/find_cyclic_reactions.py
+++ b/src/cobra/flux_analysis/find_cyclic_reactions.py
@@ -1,0 +1,152 @@
+from typing import TYPE_CHECKING, Optional, List, Tuple
+
+import numpy as np
+import optlang
+from optlang.symbolics import Zero
+
+from ..util import solver as sutil
+from ..util import create_stoichiometric_matrix
+from .helpers import normalize_cutoff
+
+
+if TYPE_CHECKING:
+    from cobra import Model
+
+
+def _create_find_cyclic_reactions_problem(
+    solver: "optlang.interface",
+    s_int: np.ndarray,
+    directions_int: np.ndarray,
+    zero_cutoff: float,
+    bound: float
+) -> Tuple["optlang.interface.Model", List["optlang.interface.Variable"]]:
+    model = solver.Model()
+    
+    q_list = []
+    for i in range(s_int.shape[1]):
+        q = solver.Variable(
+            name=f'q_{i}',
+            lb=bound*min(0, directions_int[i, 0]),
+            ub=bound*max(0, directions_int[i, 1]),
+            problem=model
+        )
+        q_list.append(q)
+    model.add(q_list)
+
+    for idx, row in enumerate(s_int):
+        nnz_list = np.flatnonzero(np.abs(row) > zero_cutoff)
+        if len(nnz_list) == 0:
+            continue
+        constraint = solver.Constraint(
+            Zero,
+            lb=0.0,
+            ub=0.0,
+            problem=model,
+            name=f'row_{idx}'
+        )
+        model.add([constraint], sloppy=True)
+        constraint.set_linear_coefficients({q_list[i]: row[i] for i in nnz_list})
+
+    model.objective = solver.Objective(Zero)
+
+    return model, q_list
+
+
+def find_cyclic_reactions(
+    model: "Model",
+    zero_cutoff: Optional[float] = None,
+    bound: float = 1e4,
+    method: str = "optimized"
+) -> List[str]:
+    """
+        TODO: @isaf27
+    """
+    zero_cutoff = normalize_cutoff(model, zero_cutoff)
+
+    internal = [i for i, r in enumerate(model.reactions) if not r.boundary]
+    s_int = create_stoichiometric_matrix(model)[:, np.array(internal)]
+    n = s_int.shape[1]
+
+    bounds_int = np.array([model.reactions[i].bounds for i in internal])
+    directions_int = np.sign(bounds_int)
+
+    lp, q_list = _create_find_cyclic_reactions_problem(
+        model.problem,
+        s_int,
+        directions_int,
+        zero_cutoff,
+        bound
+    )
+    
+    candidate_reactions = list(range(n))
+
+    if method == "optimized":
+        is_active = [False] * n
+
+        random_checks_left_count = 3
+        def set_random_weights():
+            nonlocal random_checks_left_count
+            random_checks_left_count -= 1
+            
+            weights = np.random.uniform(0.5, 1.0, size=n) * (2 * np.random.randint(low=0, high=2, size=n) - 1)
+            weights /= np.sum(np.abs(weights))
+            lp.objective.set_linear_coefficients({q_list[i]: weights[i] for i in range(n) if not is_active[i]})
+
+        set_random_weights()
+        dir_order = ["min", "max"]
+
+        while True:
+            found_active = False
+            reverse_dir_order = False
+
+            for dir in dir_order:
+                lp.objective.direction = dir
+                lp.optimize()
+
+                sutil.check_solver_status(lp.status)
+
+                if abs(lp.objective.value) > zero_cutoff:
+                    remove_coef = {}
+                    for i in range(n):
+                        if not is_active[i] and abs(q_list[i].primal) > zero_cutoff:
+                            is_active[i] = True
+                            remove_coef[q_list[i]] = 0
+                    found_active = True
+                    lp.objective.set_linear_coefficients(remove_coef)
+                    break
+
+                reverse_dir_order = True
+
+            if not found_active:
+                if random_checks_left_count > 0:
+                    set_random_weights()
+                    continue
+                break
+
+            if reverse_dir_order:
+                dir_order.reverse()
+
+        candidate_reactions = [i for i in range(n) if is_active[i]]
+
+    can_positive = [False] * n
+    can_negative = [False] * n
+    lp.objective = model.problem.Objective(Zero, direction="max")
+    for i in candidate_reactions:
+        for dir in ["min", "max"]:
+            lp.objective.set_linear_coefficients({q_list[i]: 1.0 if dir == "max" else -1.0})
+            
+            lp.optimize()
+            sutil.check_solver_status(lp.status)
+            
+            if lp.objective.value > zero_cutoff:
+                if dir == "max":
+                    can_positive[i] = True
+                else:
+                    can_negative[i] = True
+
+        lp.objective.set_linear_coefficients({q_list[i]: 0.0})
+
+    cyclic_reactions = [model.reactions[internal[i]].id for i in range(n) if can_positive[i] or can_negative[i]]
+    cyclic_reactions_directions = [(can_positive[i], can_negative[i]) for i in range(n) if can_positive[i] or can_negative[i]]
+
+    return cyclic_reactions, cyclic_reactions_directions

--- a/src/cobra/flux_analysis/find_cyclic_reactions.py
+++ b/src/cobra/flux_analysis/find_cyclic_reactions.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Optional, List, Tuple
 
+import time
 import numpy as np
 import optlang
 from optlang.symbolics import Zero
@@ -77,8 +78,10 @@ def find_cyclic_reactions(
         zero_cutoff,
         bound
     )
-    
+
     candidate_reactions = list(range(n))
+    can_positive = [False] * n
+    can_negative = [False] * n
 
     if method == "optimized":
         is_active = [False] * n
@@ -111,6 +114,11 @@ def find_cyclic_reactions(
                         if not is_active[i] and abs(q_list[i].primal) > zero_cutoff:
                             is_active[i] = True
                             remove_coef[q_list[i]] = 0
+                            if q_list[i].primal > zero_cutoff:
+                                can_positive[i] = True
+                            else:
+                                can_negative[i] = True
+
                     found_active = True
                     lp.objective.set_linear_coefficients(remove_coef)
                     break
@@ -128,16 +136,20 @@ def find_cyclic_reactions(
 
         candidate_reactions = [i for i in range(n) if is_active[i]]
 
-    can_positive = [False] * n
-    can_negative = [False] * n
     lp.objective = model.problem.Objective(Zero, direction="max")
     for i in candidate_reactions:
         for dir in ["min", "max"]:
+            if (dir == "min" and can_negative[i]) or (dir == "max" and can_positive[i]):
+                continue
+
+            if directions_int[i, int(dir == "max")] == 0:
+                continue
+
             lp.objective.set_linear_coefficients({q_list[i]: 1.0 if dir == "max" else -1.0})
-            
+
             lp.optimize()
             sutil.check_solver_status(lp.status)
-            
+
             if lp.objective.value > zero_cutoff:
                 if dir == "max":
                     can_positive[i] = True

--- a/src/cobra/flux_analysis/loopless.py
+++ b/src/cobra/flux_analysis/loopless.py
@@ -1,20 +1,26 @@
 """Provide functions to remove thermodynamically infeasible loops."""
 
-from typing import TYPE_CHECKING, Dict, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union, List
 
 import numpy as np
 from optlang.symbolics import Zero
 
 from ..core import get_solution
-from ..util import create_stoichiometric_matrix, nullspace
+from ..util import create_stoichiometric_matrix, nullspace, nullspace_fast_snp
 from .helpers import normalize_cutoff
+from .find_cyclic_reactions import find_cyclic_reactions
 
 
 if TYPE_CHECKING:
     from cobra import Model, Reaction, Solution
 
 
-def add_loopless(model: "Model", zero_cutoff: Optional[float] = None) -> None:
+def add_loopless(
+    model: "Model",
+    zero_cutoff: Optional[float] = None,
+    method: str = "original",
+    reactions: Optional[List[str]] = None
+) -> None:
     """Modify a model so all feasible flux distributions are loopless.
 
     It adds variables and constraints to a model which will disallow flux
@@ -35,6 +41,10 @@ def add_loopless(model: "Model", zero_cutoff: Optional[float] = None) -> None:
         Cutoff used for null space. Coefficients with an absolute value
         smaller than `zero_cutoff` are considered to be zero. The default
         uses the `model.tolerance` (default None).
+    method : str, "original" or "fastSNP", optional
+        TODO: @isaf27
+    reactions : list of str, optional
+        TODO: @isaf27
 
     References
     ----------
@@ -44,18 +54,43 @@ def add_loopless(model: "Model", zero_cutoff: Optional[float] = None) -> None:
        in: Biophys J. 2011 Mar 2;100(5):1381.
 
     """
+    if method not in ["original", "fastSNP"]:
+        raise ValueError(f"unsupported method: {method}")
+
     zero_cutoff = normalize_cutoff(model, zero_cutoff)
 
-    internal = [i for i, r in enumerate(model.reactions) if not r.boundary]
-    s_int = create_stoichiometric_matrix(model)[:, np.array(internal)]
-    n_int = nullspace(s_int).T
+    if reactions is None and method == "fastSNP":
+        reactions, _ = find_cyclic_reactions(model, zero_cutoff=zero_cutoff)
+
+    reactions_to_constrain = [i for i, r in enumerate(model.reactions) if not r.boundary]
+    if reactions is not None:
+        reactions_set = set(reactions)
+        reactions_to_constrain = [
+            i for i, r in enumerate(model.reactions) if not r.boundary and r.id in reactions_set
+        ]
+
+    s_int = create_stoichiometric_matrix(model)[:, np.array(reactions_to_constrain)]
+
+    if method == "original":
+        n_int = nullspace(s_int).T
+    elif method == "fastSNP":
+        bounds_int = np.array([model.reactions[i].bounds for i in reactions_to_constrain])
+        directions_int = np.sign(bounds_int)
+        v_bound = np.max(np.abs(bounds_int))
+        n_int = nullspace_fast_snp(model.problem, s_int, directions_int, v_bound=v_bound, zero_cutoff=zero_cutoff).T
+    else:
+        raise ValueError(f"unsupported method: {method}")
+
     max_bound = max(max(abs(b) for b in r.bounds) for r in model.reactions)
     prob = model.problem
 
     # Add indicator variables and new constraints
     to_add = []
-    for i in internal:
-        rxn = model.reactions[i]
+    for i, ridx in enumerate(reactions_to_constrain):
+        if not (np.abs(n_int[:, i]) > zero_cutoff).any():
+            continue
+
+        rxn = model.reactions[ridx]
         # indicator variable a_i
         indicator = prob.Variable(f"indicator_{rxn.id}", type="binary")
         # -M*(1 - a_i) <= v_i <= M*a_i
@@ -84,7 +119,7 @@ def add_loopless(model: "Model", zero_cutoff: Optional[float] = None) -> None:
         model.add_cons_vars([nullspace_constraint])
         coefs = {
             model.variables[f"delta_g_{model.reactions[ridx].id}"]: row[i]
-            for i, ridx in enumerate(internal)
+            for i, ridx in enumerate(reactions_to_constrain)
             if abs(row[i]) > zero_cutoff
         }
         model.constraints[name].set_linear_coefficients(coefs)

--- a/src/cobra/flux_analysis/loopless.py
+++ b/src/cobra/flux_analysis/loopless.py
@@ -1,14 +1,14 @@
 """Provide functions to remove thermodynamically infeasible loops."""
 
-from typing import TYPE_CHECKING, Dict, Optional, Union, List
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import numpy as np
 from optlang.symbolics import Zero
 
 from ..core import get_solution
 from ..util import create_stoichiometric_matrix, nullspace, nullspace_fast_snp
-from .helpers import normalize_cutoff
 from .find_cyclic_reactions import find_cyclic_reactions
+from .helpers import normalize_cutoff
 
 
 if TYPE_CHECKING:
@@ -18,14 +18,17 @@ if TYPE_CHECKING:
 def add_loopless(
     model: "Model",
     zero_cutoff: Optional[float] = None,
-    method: str = "original",
-    reactions: Optional[List[str]] = None
+    method: str = "fastSNP",
+    reactions: Optional[List[str]] = None,
 ) -> None:
     """Modify a model so all feasible flux distributions are loopless.
 
     It adds variables and constraints to a model which will disallow flux
-    distributions with loops. The used formulation is described in [1]_.
-    This function *will* modify your model.
+    distributions with loops. This function *will* modify your model.
+
+    The used formulation is described in [1]_. If `method` is set to
+    "fastSNP", it uses a faster implementation based on the Fast-SNP
+    algorithm [2]_.
 
     In most cases you probably want to use the much faster
     `loopless_solution`. May be used in cases where you want to add complex
@@ -42,9 +45,13 @@ def add_loopless(
         smaller than `zero_cutoff` are considered to be zero. The default
         uses the `model.tolerance` (default None).
     method : str, "original" or "fastSNP", optional
-        TODO: @isaf27
+        The method to use for finding the null space. The "original" method
+        uses the original method from [1]_, while "fastSNP" uses a faster
+        implementation based on the FastSNP algorithm. The "fastSNP" method
+        is much faster and should be used in most cases.
     reactions : list of str, optional
-        TODO: @isaf27
+        The list of reaction IDs to constrain. All cycles within these
+        reactions will be removed. If `None`, all reactions will be constrained.
 
     References
     ----------
@@ -52,7 +59,9 @@ def add_loopless(
        metabolic models. Schellenberger J, Lewis NE, Palsson BO. Biophys J.
        2011 Feb 2;100(3):544-53. doi: 10.1016/j.bpj.2010.12.3707. Erratum
        in: Biophys J. 2011 Mar 2;100(5):1381.
-
+    .. [2] Fast-SNP: a fast matrix pre-processing algorithm for efficient
+       loopless flux optimization of metabolic models. Saa PA, Nielsen LK.
+       Bioinformatics. 2016 Dec;32(24):3807–3814. doi: 10.1093/bioinformatics/btw555.
     """
     if method not in ["original", "fastSNP"]:
         raise ValueError(f"unsupported method: {method}")
@@ -62,11 +71,15 @@ def add_loopless(
     if reactions is None and method == "fastSNP":
         reactions = find_cyclic_reactions(model, zero_cutoff=zero_cutoff)[0]
 
-    reactions_to_constrain = [i for i, r in enumerate(model.reactions) if not r.boundary]
+    reactions_to_constrain = [
+        i for i, r in enumerate(model.reactions) if not r.boundary
+    ]
     if reactions is not None:
         reactions_set = set(reactions)
         reactions_to_constrain = [
-            i for i, r in enumerate(model.reactions) if not r.boundary and r.id in reactions_set
+            i
+            for i, r in enumerate(model.reactions)
+            if not r.boundary and r.id in reactions_set
         ]
 
     s_int = create_stoichiometric_matrix(model)[:, np.array(reactions_to_constrain)]
@@ -74,10 +87,18 @@ def add_loopless(
     if method == "original":
         n_int = nullspace(s_int).T
     elif method == "fastSNP":
-        bounds_int = np.array([model.reactions[i].bounds for i in reactions_to_constrain])
+        bounds_int = np.array(
+            [model.reactions[i].bounds for i in reactions_to_constrain]
+        )
         directions_int = np.sign(bounds_int)
         v_bound = np.max(np.abs(bounds_int))
-        n_int = nullspace_fast_snp(model.problem, s_int, directions_int, v_bound=v_bound, zero_cutoff=zero_cutoff).T
+        n_int = nullspace_fast_snp(
+            model.problem,
+            s_int,
+            directions_int,
+            v_bound=v_bound,
+            zero_cutoff=zero_cutoff,
+        ).T
     else:
         raise ValueError(f"unsupported method: {method}")
 

--- a/src/cobra/flux_analysis/loopless.py
+++ b/src/cobra/flux_analysis/loopless.py
@@ -60,7 +60,7 @@ def add_loopless(
     zero_cutoff = normalize_cutoff(model, zero_cutoff)
 
     if reactions is None and method == "fastSNP":
-        reactions, _ = find_cyclic_reactions(model, zero_cutoff=zero_cutoff)
+        reactions = find_cyclic_reactions(model, zero_cutoff=zero_cutoff)[0]
 
     reactions_to_constrain = [i for i, r in enumerate(model.reactions) if not r.boundary]
     if reactions is not None:

--- a/src/cobra/flux_analysis/variability.py
+++ b/src/cobra/flux_analysis/variability.py
@@ -1,7 +1,7 @@
 """Provide variability based methods such as flux variability or gene essentiality."""
 
 import logging
-from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Union, Dict
 from warnings import warn
 
 import numpy as np
@@ -13,8 +13,9 @@ from ..util import ProcessPool
 from ..util import solver as sutil
 from .deletion import single_gene_deletion, single_reaction_deletion
 from .helpers import normalize_cutoff
-from .loopless import loopless_fva_iter
+from .loopless import loopless_fva_iter, add_loopless
 from .parsimonious import add_pfba
+from .find_cyclic_reactions import find_cyclic_reactions
 
 
 if TYPE_CHECKING:
@@ -88,12 +89,11 @@ def _fva_step(reaction_id: str) -> Tuple[str, float]:
     return reaction_id, value
 
 
-# TODO: @isaf27
 def flux_variability_analysis(
     model: "Model",
     reaction_list: Optional[List[Union["Reaction", str]]] = None,
     loopless: bool = False,
-    add_loopless_method: Optional[str] = None,
+    add_loopless_params: Optional[Dict[str, any]] = None,
     fraction_of_optimum: float = 1.0,
     pfba_factor: Optional[float] = None,
     processes: Optional[int] = None,
@@ -165,13 +165,8 @@ def flux_variability_analysis(
        doi: 10.1093/bioinformatics/btv096.
 
     """
-    if add_loopless_method is not None and not loopless:
-        raise ValueError("The `add_loopless_method` argument can be used only if loopless=True.")
-
-    if loopless:
-        # TODO: @isaf27
-        # find_cyclic_reactions
-        pass
+    if add_loopless_params is not None and not loopless:
+        raise ValueError("The `add_loopless_params` argument can be used only if loopless=True.")
 
     if reaction_list is None:
         reaction_ids = [r.id for r in model.reactions]
@@ -191,6 +186,31 @@ def flux_variability_analysis(
         },
         index=reaction_ids,
     )
+
+    reaction_ids_by_type = [
+        {
+            "minimum": [],
+            "maximum": [],
+        },
+        {
+            "minimum": [],
+            "maximum": [],
+        }
+    ]
+    if loopless:
+        cyclic_reactions, cyclic_directions = find_cyclic_reactions(model)
+        cyclic_reaction_index = {r_id: i for i, r_id in enumerate(cyclic_reactions)}
+        for r_id in reaction_ids:
+            i = cyclic_reaction_index.get(r_id)
+            for loc, dir in enumerate(("minimum", "maximum")):
+                if i is not None and cyclic_directions[i][loc]:
+                    reaction_ids_by_type[1][dir].append(r_id)
+                else:
+                    reaction_ids_by_type[0][dir].append(r_id)
+    else:
+        reaction_ids_by_type[0]["minimum"] = reaction_ids
+        reaction_ids_by_type[0]["maximum"] = reaction_ids
+
     prob = model.problem
     with model:
         # Safety check before setting up FVA.
@@ -239,25 +259,42 @@ def flux_variability_analysis(
             model.add_cons_vars([flux_sum, flux_sum_constraint])
 
         model.objective = Zero  # This will trigger the reset as well
-        for what in ("minimum", "maximum"):
-            if processes > 1:
-                # We create and destroy a new pool here in order to set the
-                # objective direction for all reactions. This creates a
-                # slight overhead but seems the most clean.
-                chunk_size = len(reaction_ids) // processes
-                with ProcessPool(
-                    processes,
-                    initializer=_init_worker,
-                    initargs=(model, loopless, what[:3]),
-                ) as pool:
-                    for rxn_id, value in pool.imap_unordered(
-                        _fva_step, reaction_ids, chunksize=chunk_size
-                    ):
+        for loopless, opt_reaction_ids in enumerate(reaction_ids_by_type):
+            if len(opt_reaction_ids["minimum"]) == 0 and len(opt_reaction_ids["maximum"]) == 0:
+                continue
+
+            step_loopless = loopless
+            if loopless and add_loopless_params is not None:
+                add_loopless(
+                    model,
+                    reactions=cyclic_reactions,
+                    **add_loopless_params,
+                )
+                step_loopless = False
+
+            for what in ("minimum", "maximum"):
+                if len(opt_reaction_ids[what]) == 0:
+                    continue
+
+                cur_processes = min(processes, len(opt_reaction_ids[what]))
+                if cur_processes > 1:
+                    # We create and destroy a new pool here in order to set the
+                    # objective direction for all reactions. This creates a
+                    # slight overhead but seems the most clean.
+                    chunk_size = len(opt_reaction_ids[what]) // cur_processes
+                    with ProcessPool(
+                        cur_processes,
+                        initializer=_init_worker,
+                        initargs=(model, step_loopless, what[:3]),
+                    ) as pool:
+                        for rxn_id, value in pool.imap_unordered(
+                            _fva_step, opt_reaction_ids[what], chunksize=chunk_size
+                        ):
+                            fva_result.at[rxn_id, what] = value
+                else:
+                    _init_worker(model, step_loopless, what[:3])
+                    for rxn_id, value in map(_fva_step, opt_reaction_ids[what]):
                         fva_result.at[rxn_id, what] = value
-            else:
-                _init_worker(model, loopless, what[:3])
-                for rxn_id, value in map(_fva_step, reaction_ids):
-                    fva_result.at[rxn_id, what] = value
 
     return fva_result[["minimum", "maximum"]]
 

--- a/src/cobra/flux_analysis/variability.py
+++ b/src/cobra/flux_analysis/variability.py
@@ -88,10 +88,12 @@ def _fva_step(reaction_id: str) -> Tuple[str, float]:
     return reaction_id, value
 
 
+# TODO: @isaf27
 def flux_variability_analysis(
     model: "Model",
     reaction_list: Optional[List[Union["Reaction", str]]] = None,
     loopless: bool = False,
+    add_loopless_method: Optional[str] = None,
     fraction_of_optimum: float = 1.0,
     pfba_factor: Optional[float] = None,
     processes: Optional[int] = None,
@@ -163,6 +165,14 @@ def flux_variability_analysis(
        doi: 10.1093/bioinformatics/btv096.
 
     """
+    if add_loopless_method is not None and not loopless:
+        raise ValueError("The `add_loopless_method` argument can be used only if loopless=True.")
+
+    if loopless:
+        # TODO: @isaf27
+        # find_cyclic_reactions
+        pass
+
     if reaction_list is None:
         reaction_ids = [r.id for r in model.reactions]
     else:

--- a/src/cobra/flux_analysis/variability.py
+++ b/src/cobra/flux_analysis/variability.py
@@ -1,7 +1,7 @@
 """Provide variability based methods such as flux variability or gene essentiality."""
 
 import logging
-from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Union, Dict
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 from warnings import warn
 
 import numpy as np
@@ -12,10 +12,10 @@ from ..core import Configuration, get_solution
 from ..util import ProcessPool
 from ..util import solver as sutil
 from .deletion import single_gene_deletion, single_reaction_deletion
-from .helpers import normalize_cutoff
-from .loopless import loopless_fva_iter, add_loopless
-from .parsimonious import add_pfba
 from .find_cyclic_reactions import find_cyclic_reactions
+from .helpers import normalize_cutoff
+from .loopless import add_loopless, loopless_fva_iter
+from .parsimonious import add_pfba
 
 
 if TYPE_CHECKING:
@@ -110,6 +110,13 @@ def flux_variability_analysis(
     loopless : bool, optional
         Whether to return only loopless solutions. This is significantly
         slower. Please also refer to the notes (default False).
+    add_loopless_params : dict, optional
+        If not set, `add_loopless` will not be used. Otherwise, this
+        dictionary will be used to pass parameters to the `add_loopless`
+        function. The parameters are passed as keyword arguments, so the
+        keys of the dictionary should match the parameter names of
+        `add_loopless`. This parameter can be used only if `loopless`
+        is set to True.
     fraction_of_optimum : float, optional
         Must be <= 1.0. Requires that the objective value is at least the
         fraction times maximum objective value. A value of 0.85 for instance
@@ -145,11 +152,16 @@ def flux_variability_analysis(
     sub-optimal.
 
     Using the loopless option will lead to a significant increase in
-    computation time (about a factor of 100 for large models). However, the
-    algorithm used here (see [2]_) is still more than 1000x faster than the
-    "naive" version using `add_loopless(model)`. Also note that if you have
-    included constraints that force a loop (for instance by setting all fluxes
-    in a loop to be non-zero) this loop will be included in the solution.
+    computation time (about a factor of 100 for large models).
+
+    If `add_loopless_params` is not set, the loops removal algorithm will be
+    used (see [2]_). This algorithm does not guarantee to find optimal bounds.
+
+    If `add_loopless_params` is set, the `add_loopless` function will be
+    used to add constraints that will remove loops from the model. Please
+    refer to the documentation of `add_loopless` for more information on
+    the parameters, or just use `{}` to use the default parameters. In this
+    case, the efficient Fast-SNP algorithm (see [3]_) will be used.
 
     References
     ----------
@@ -164,9 +176,14 @@ def flux_variability_analysis(
        Bioinformatics. 2015 Jul 1;31(13):2159-65.
        doi: 10.1093/bioinformatics/btv096.
 
+    .. [3] Fast-SNP: a fast matrix pre-processing algorithm for efficient
+       loopless flux optimization of metabolic models. Saa PA, Nielsen LK.
+       Bioinformatics. 2016 Dec;32(24):3807–3814. doi: 10.1093/bioinformatics/btw555.
     """
     if add_loopless_params is not None and not loopless:
-        raise ValueError("The `add_loopless_params` argument can be used only if loopless=True.")
+        raise ValueError(
+            "The `add_loopless_params` argument can be used only if loopless=True."
+        )
 
     if reaction_list is None:
         reaction_ids = [r.id for r in model.reactions]
@@ -195,7 +212,7 @@ def flux_variability_analysis(
         {
             "minimum": [],
             "maximum": [],
-        }
+        },
     ]
     if loopless:
         cyclic_reactions, cyclic_directions = find_cyclic_reactions(model)
@@ -259,8 +276,8 @@ def flux_variability_analysis(
             model.add_cons_vars([flux_sum, flux_sum_constraint])
 
         model.objective = Zero  # This will trigger the reset as well
-        for loopless, opt_reaction_ids in enumerate(reaction_ids_by_type):
-            if len(opt_reaction_ids["minimum"]) == 0 and len(opt_reaction_ids["maximum"]) == 0:
+        for loopless, opt_rxn_ids in enumerate(reaction_ids_by_type):
+            if len(opt_rxn_ids["minimum"]) == 0 and len(opt_rxn_ids["maximum"]) == 0:
                 continue
 
             step_loopless = loopless
@@ -273,27 +290,27 @@ def flux_variability_analysis(
                 step_loopless = False
 
             for what in ("minimum", "maximum"):
-                if len(opt_reaction_ids[what]) == 0:
+                if len(opt_rxn_ids[what]) == 0:
                     continue
 
-                cur_processes = min(processes, len(opt_reaction_ids[what]))
+                cur_processes = min(processes, len(opt_rxn_ids[what]))
                 if cur_processes > 1:
                     # We create and destroy a new pool here in order to set the
                     # objective direction for all reactions. This creates a
                     # slight overhead but seems the most clean.
-                    chunk_size = len(opt_reaction_ids[what]) // cur_processes
+                    chunk_size = len(opt_rxn_ids[what]) // cur_processes
                     with ProcessPool(
                         cur_processes,
                         initializer=_init_worker,
                         initargs=(model, step_loopless, what[:3]),
                     ) as pool:
                         for rxn_id, value in pool.imap_unordered(
-                            _fva_step, opt_reaction_ids[what], chunksize=chunk_size
+                            _fva_step, opt_rxn_ids[what], chunksize=chunk_size
                         ):
                             fva_result.at[rxn_id, what] = value
                 else:
                     _init_worker(model, step_loopless, what[:3])
-                    for rxn_id, value in map(_fva_step, opt_reaction_ids[what]):
+                    for rxn_id, value in map(_fva_step, opt_rxn_ids[what]):
                         fva_result.at[rxn_id, what] = value
 
     return fva_result[["minimum", "maximum"]]

--- a/src/cobra/util/__init__.py
+++ b/src/cobra/util/__init__.py
@@ -3,3 +3,4 @@ from cobra.util.context import *
 from cobra.util.solver import *
 from cobra.util.util import *
 from cobra.util.process_pool import *
+from cobra.util.fast_snp import *

--- a/src/cobra/util/fast_snp.py
+++ b/src/cobra/util/fast_snp.py
@@ -1,0 +1,139 @@
+import numpy as np
+
+from typing import Tuple, List
+
+import optlang
+from optlang.interface import Model, Variable, OPTIMAL
+from optlang.symbolics import Zero
+
+
+def _solve_snv(weights: np.ndarray, model: Model, v_list: List[Variable], positive: bool) -> np.ndarray:
+    dir = 1 if positive else -1
+
+    model.constraints["nonzero_constraint"].set_linear_coefficients({
+        variable: weight * dir
+        for variable, weight in zip(v_list, weights)
+    })
+
+    model.optimize()
+    if model.status != OPTIMAL:
+        return None
+
+    result = np.array([variable.primal for variable in v_list])
+    result /= np.linalg.norm(result)
+
+    return result
+
+
+def _create_fast_snp_problem(
+    solver: "optlang.interface",
+    S: np.ndarray,
+    directions: np.ndarray,
+    v_bound: float,
+    zero_cutoff: float,
+    bias: float,
+) -> Tuple[Model, List[Variable]]:
+    n = S.shape[1]
+
+    model = solver.Model()
+    x_list = []
+    v_list = []
+
+    for i in range(n):
+        x = solver.Variable(name=f'x_{i}', lb=0, problem=model)
+        v = solver.Variable(name=f'v_{i}', 
+                            lb=v_bound*min(directions[i, 0], 0),
+                            ub=v_bound*max(directions[i, 1], 0),
+                            problem=model)
+        model.add([x, v])
+        x_list.append(x)
+        v_list.append(v)
+        
+        constraint1 = solver.Constraint(Zero, lb=0.0, problem=model, name=f'modulo_constraint1_{i}')
+        constraint2 = solver.Constraint(Zero, lb=0.0, problem=model, name=f'modulo_constraint2_{i}')
+        model.add([constraint1, constraint2], sloppy=True)
+        
+        constraint1.set_linear_coefficients({x: 1.0, v: -1.0})
+        constraint2.set_linear_coefficients({x: 1.0, v: 1.0})
+
+    for idx, row in enumerate(S):
+        nnz_list = np.flatnonzero(np.abs(row) > zero_cutoff)
+        if len(nnz_list) == 0:
+            continue
+
+        constraint = solver.Constraint(
+            Zero,
+            lb=0.0,
+            ub=0.0,
+            problem=model,
+            name=f'row_{idx}'
+        )
+        model.add([constraint], sloppy=True)
+        constraint.set_linear_coefficients({v_list[i]: row[i] for i in nnz_list})
+
+    model.add([solver.Constraint(
+        Zero,
+        lb=bias,
+        problem=model,
+        name="nonzero_constraint",
+    )], sloppy=True)
+
+    model.objective = solver.Objective(Zero)
+    model.objective.set_linear_coefficients({x: 1 for x in x_list})
+    model.objective.direction = "min"
+
+    return model, v_list
+
+
+def _project(N: np.ndarray, w: np.ndarray) -> np.ndarray:
+    return w - (N.T @ (N @ w))
+
+
+def _get_condition_vector(N: np.ndarray) -> np.ndarray:
+    return _project(N, np.random.uniform(-1.0, 1.0, size=N.shape[1]))
+
+
+def nullspace_fast_snp(
+    solver: "optlang.interface",
+    S: np.ndarray,
+    directions: np.ndarray,
+    v_bound: float = 1e4,
+    zero_cutoff: float = 1e-6,
+    bias: float = 1e-3,
+) -> np.ndarray:
+    """
+        TODO: @isaf27
+    """
+
+    problem, v_list = _create_fast_snp_problem(solver, S, directions, v_bound, zero_cutoff, bias)
+
+    n = S.shape[1]
+    N = np.zeros((0, n))
+    U = np.zeros((0, n))
+
+    for _ in range(n):
+        weights = _get_condition_vector(U)
+
+        v1 = _solve_snv(weights, problem, v_list, True)
+        v2 = _solve_snv(weights, problem, v_list, False)
+
+        if v1 is None and v2 is None:
+            break
+
+        v = v1
+        if v1 is None:
+            v = v2
+
+        if v1 is not None and v2 is not None:
+            nnz_v1 = np.sum(np.abs(v1) > zero_cutoff)
+            nnz_v2 = np.sum(np.abs(v2) > zero_cutoff)
+            if nnz_v1 > nnz_v2:
+                v = v2
+
+        N = np.vstack([N, v])
+
+        v = _project(U, v)
+        v /= np.linalg.norm(v)
+        U = np.vstack([U, v])
+
+    return N.T

--- a/src/cobra/util/fast_snp.py
+++ b/src/cobra/util/fast_snp.py
@@ -72,7 +72,7 @@ def _create_fast_snp_problem(
         constraint = solver.Constraint(Zero, lb=0.0, ub=0.0, name=f"row_{idx}")
         model.add([constraint], sloppy=True)
         model.constraints[f"row_{idx}"].set_linear_coefficients(
-            {x_list[i]: row[i] for i in nnz_list}
+            {v_list[i]: row[i] for i in nnz_list}
         )
 
     model.add(
@@ -80,7 +80,6 @@ def _create_fast_snp_problem(
             solver.Constraint(
                 Zero,
                 lb=bias,
-                problem=model,
                 name="nonzero_constraint",
             )
         ],

--- a/src/cobra/util/fast_snp.py
+++ b/src/cobra/util/fast_snp.py
@@ -1,19 +1,21 @@
+"""Provides Fast-SNP algorithm implementation for finding nullspace basis of matrix."""
+
+from typing import List, Tuple
+
 import numpy as np
-
-from typing import Tuple, List
-
 import optlang
-from optlang.interface import Model, Variable, OPTIMAL
+from optlang.interface import OPTIMAL, Model, Variable
 from optlang.symbolics import Zero
 
 
-def _solve_snv(weights: np.ndarray, model: Model, v_list: List[Variable], positive: bool) -> np.ndarray:
+def _solve_snv(
+    weights: np.ndarray, model: Model, v_list: List[Variable], positive: bool
+) -> np.ndarray:
     dir = 1 if positive else -1
 
-    model.constraints["nonzero_constraint"].set_linear_coefficients({
-        variable: weight * dir
-        for variable, weight in zip(v_list, weights)
-    })
+    model.constraints["nonzero_constraint"].set_linear_coefficients(
+        {variable: weight * dir for variable, weight in zip(v_list, weights)}
+    )
 
     model.optimize()
     if model.status != OPTIMAL:
@@ -40,43 +42,50 @@ def _create_fast_snp_problem(
     v_list = []
 
     for i in range(n):
-        x = solver.Variable(name=f'x_{i}', lb=0, problem=model)
-        v = solver.Variable(name=f'v_{i}', 
-                            lb=v_bound*min(directions[i, 0], 0),
-                            ub=v_bound*max(directions[i, 1], 0),
-                            problem=model)
+        x = solver.Variable(name=f"x_{i}", lb=0, problem=model)
+        v = solver.Variable(
+            name=f"v_{i}",
+            lb=v_bound * min(directions[i, 0], 0),
+            ub=v_bound * max(directions[i, 1], 0),
+            problem=model,
+        )
         model.add([x, v])
         x_list.append(x)
         v_list.append(v)
-        
-        constraint1 = solver.Constraint(Zero, lb=0.0, problem=model, name=f'modulo_constraint1_{i}')
-        constraint2 = solver.Constraint(Zero, lb=0.0, problem=model, name=f'modulo_constraint2_{i}')
+
+        constraint1 = solver.Constraint(Zero, lb=0.0, name=f"modulo_constraint1_{i}")
+        constraint2 = solver.Constraint(Zero, lb=0.0, name=f"modulo_constraint2_{i}")
         model.add([constraint1, constraint2], sloppy=True)
-        
-        constraint1.set_linear_coefficients({x: 1.0, v: -1.0})
-        constraint2.set_linear_coefficients({x: 1.0, v: 1.0})
+
+        model.constraints[f"modulo_constraint1_{i}"].set_linear_coefficients(
+            {x: 1.0, v: -1.0}
+        )
+        model.constraints[f"modulo_constraint2_{i}"].set_linear_coefficients(
+            {x: 1.0, v: 1.0}
+        )
 
     for idx, row in enumerate(S):
         nnz_list = np.flatnonzero(np.abs(row) > zero_cutoff)
         if len(nnz_list) == 0:
             continue
 
-        constraint = solver.Constraint(
-            Zero,
-            lb=0.0,
-            ub=0.0,
-            problem=model,
-            name=f'row_{idx}'
-        )
+        constraint = solver.Constraint(Zero, lb=0.0, ub=0.0, name=f"row_{idx}")
         model.add([constraint], sloppy=True)
-        constraint.set_linear_coefficients({v_list[i]: row[i] for i in nnz_list})
+        model.constraints[f"row_{idx}"].set_linear_coefficients(
+            {x_list[i]: row[i] for i in nnz_list}
+        )
 
-    model.add([solver.Constraint(
-        Zero,
-        lb=bias,
-        problem=model,
-        name="nonzero_constraint",
-    )], sloppy=True)
+    model.add(
+        [
+            solver.Constraint(
+                Zero,
+                lb=bias,
+                problem=model,
+                name="nonzero_constraint",
+            )
+        ],
+        sloppy=True,
+    )
 
     model.objective = solver.Objective(Zero)
     model.objective.set_linear_coefficients({x: 1 for x in x_list})
@@ -101,11 +110,57 @@ def nullspace_fast_snp(
     zero_cutoff: float = 1e-6,
     bias: float = 1e-3,
 ) -> np.ndarray:
-    """
-        TODO: @isaf27
+    """Compute an approximate basis for the nullspace of S with coordinate directions.
+
+    The algorithm used by this function is described in [1]_.
+
+    Parameters
+    ----------
+    solver : "optlang.interface"
+        The solver interface to use for the optimization problem.
+        You can use `model.problem` to get the solver interface.
+    S : numpy.ndarray
+        The matrix for which the nullspace is computed.
+        `S` should be a 2-D array.
+    directions : numpy.ndarray
+        A 2-D array with shape (k, 2) where `k` is the number of columns in `S`.
+        This array specifies the directions of coordinates.
+        Each row should be:
+            - [0, 0] for coordinates that can be only zero
+            - [0, 1] for coordinates that can be only positive
+            - [-1, 0] for coordinates that can be only negative
+            - [-1, 1] for coordinates that can be both positive and negative
+    v_bound : float, optional
+        The bound for the variables in the optimization problem (default 1e4).
+    zero_cutoff : float, optional
+        The cutoff value to consider a coordinate value as zero (default 1e-6).
+    bias : float, optional
+        The bias for the non-zero constraint in the optimization problem
+        (default 1e-3).
+
+    Returns
+    -------
+    numpy.ndarray
+        If `S` is an array with shape (m, k), then an array
+        with shape (k, n) will be returned, where `n` is the dimension of the
+        nullspace of `S` with `directions`. Each column of this array is a basis
+        vector for the nullspace; each element in numpy.dot(S, column) will be
+        approximately zero. Each coordinate in the column will have an allowed
+        sign according to the `directions` parameter.
+
+    References
+    ----------
+    .. [1] Fast-SNP: a fast matrix pre-processing algorithm for efficient
+       loopless flux optimization of metabolic models. Saa PA, Nielsen LK.
+       Bioinformatics. 2016 Dec;32(24):3807–3814. doi: 10.1093/bioinformatics/btw555.
     """
 
-    problem, v_list = _create_fast_snp_problem(solver, S, directions, v_bound, zero_cutoff, bias)
+    if len(S.shape) != 2 or S.shape[0] == 0 or S.shape[1] == 0:
+        raise ValueError("Input matrix S must be a 2D array with non-zero dimensions.")
+
+    problem, v_list = _create_fast_snp_problem(
+        solver, S, directions, v_bound, zero_cutoff, bias
+    )
 
     n = S.shape[1]
     N = np.zeros((0, n))

--- a/tests/test_flux_analysis/test_find_cyclic_reactions.py
+++ b/tests/test_flux_analysis/test_find_cyclic_reactions.py
@@ -1,0 +1,37 @@
+"""Test finding cyclic reactions in metabolic model."""
+
+from typing import Callable, List
+
+import pytest
+
+from cobra import Model
+from cobra.flux_analysis.find_cyclic_reactions import find_cyclic_reactions
+
+
+@pytest.mark.parametrize("method", ["basic", "optimized"])
+def test_find_cyclic_reactions_benchmark(
+    large_model: Model, benchmark: Callable, all_solvers: List[str], method: str
+) -> None:
+    """Benchmark find_cyclic_reactions."""
+    large_model.solver = all_solvers
+    benchmark(
+        find_cyclic_reactions,
+        large_model,
+        method=method,
+    )
+
+
+@pytest.mark.parametrize("method", ["basic", "optimized"])
+def test_find_cyclic_reactions(
+    model: Model, all_solvers: List[str], method: str
+) -> None:
+    """Test find_cyclic_reactions."""
+    model.solver = all_solvers
+    cyclic_reactions, cyclic_directions = find_cyclic_reactions(model, method=method)
+
+    assert len(cyclic_reactions) == 2
+    assert len(cyclic_directions) == 2
+    for reaction in ["FRD7", "SUCDi"]:
+        assert reaction in cyclic_reactions, f"Expected {reaction} in cyclic reactions"
+    for directions in cyclic_directions:
+        assert directions == (False, True)

--- a/tests/test_flux_analysis/test_loopless.py
+++ b/tests/test_flux_analysis/test_loopless.py
@@ -42,13 +42,14 @@ def ll_test_model(request: pytest.FixtureRequest) -> Model:
     return test_model
 
 
-def test_loopless_benchmark_before(benchmark: Callable) -> None:
+@pytest.mark.parametrize("method", ["fastSNP", "original"])
+def test_loopless_benchmark_before(benchmark: Callable, method: str) -> None:
     """Benchmark initial condition."""
     test_model = construct_ll_test_model()
 
     def _():
         with test_model:
-            add_loopless(test_model)
+            add_loopless(test_model, method=method)
             test_model.optimize()
 
     benchmark(_)
@@ -81,9 +82,10 @@ def test_loopless_solution_fluxes(model: Model) -> None:
     assert ll_solution.objective_value == pytest.approx(sol.objective_value)
 
 
-def test_add_loopless(ll_test_model: Model) -> None:
+@pytest.mark.parametrize("method", ["fastSNP", "original"])
+def test_add_loopless(ll_test_model: Model, method: str) -> None:
     """Test add_loopless()."""
-    add_loopless(ll_test_model)
+    add_loopless(ll_test_model, method=method)
     feasible_status = ll_test_model.optimize().status
     ll_test_model.reactions.v3.lower_bound = 1
     ll_test_model.slim_optimize()

--- a/tests/test_flux_analysis/test_variability.py
+++ b/tests/test_flux_analysis/test_variability.py
@@ -60,7 +60,8 @@ def test_pfba_flux_variability(
     assert comparison["maximum"].all()
 
 
-def test_loopless_pfba_fva(model: Model) -> None:
+@pytest.mark.parametrize("method", ["", "original", "fastSNP"])
+def test_loopless_pfba_fva(model: Model, method: str) -> None:
     """Test loopless FVA using pFBA."""
     loop_reactions = [model.reactions.get_by_id(rid) for rid in ("FRD7", "SUCDi")]
     fva_loopless = flux_variability_analysis(
@@ -68,6 +69,7 @@ def test_loopless_pfba_fva(model: Model) -> None:
         pfba_factor=1.1,
         reaction_list=loop_reactions,
         loopless=True,
+        add_loopless_params=(None if len(method) == 0 else {"method": method}),
         processes=1,
     )
     assert np.allclose(fva_loopless["maximum"], fva_loopless["minimum"])
@@ -97,8 +99,9 @@ def test_parallel_flux_variability(
 
 
 # Loopless FVA
+@pytest.mark.parametrize("method", ["", "original", "fastSNP"])
 def test_flux_variability_loopless_benchmark(
-    model: Model, benchmark: Callable, all_solvers: List[str]
+    model: Model, benchmark: Callable, all_solvers: List[str], method: str
 ) -> None:
     """Benchmark loopless FVA."""
     model.solver = all_solvers
@@ -106,17 +109,24 @@ def test_flux_variability_loopless_benchmark(
         flux_variability_analysis,
         model,
         loopless=True,
+        add_loopless_params=(None if len(method) == 0 else {"method": method}),
         reaction_list=model.reactions[1::50],
     )
 
 
-def test_flux_variability_loopless(model: Model, all_solvers: List[str]) -> None:
+@pytest.mark.parametrize("method", ["", "original", "fastSNP"])
+def test_flux_variability_loopless(
+    model: Model, all_solvers: List[str], method: str
+) -> None:
     """Test loopless FVA."""
     model.solver = all_solvers
     loop_reactions = [model.reactions.get_by_id(rid) for rid in ("FRD7", "SUCDi")]
     fva_normal = flux_variability_analysis(model, reaction_list=loop_reactions)
     fva_loopless = flux_variability_analysis(
-        model, reaction_list=loop_reactions, loopless=True
+        model,
+        reaction_list=loop_reactions,
+        loopless=True,
+        add_loopless_params=(None if len(method) == 0 else {"method": method}),
     )
 
     assert not np.allclose(fva_normal["maximum"], fva_normal["minimum"])


### PR DESCRIPTION
* [ ] fix #1393 
* [ ] description of feature/fix
* [ ] tests added/passed
* [ ] add an entry to the [next release](../release-notes/next-release.md)

# TL;DR

This PR implements Fast-SNP algorithm for adding loopless constraints. It consists of two key optimizations:

- Consider for loopless constraints only the reactions that can be part of a cycle (loop).
- Build sparse $N_{\text{int}}$ matrix using Fast-SNP algorithm (https://doi.org/10.1093/bioinformatics/btw555), which takes reaction flux sign (positive/negative) into account.

As a result a 10-100x (or more) speed-up for loopless FVA is achieved.

This PR is somewhat similar to #841, but differs in implementation. 

# Code modifications

One of the key optimizations is that `add_loopless` and `flux_variability_analysis` functions use only reactions that can be a part of a cycle (we call them cyclic). This greatly improves performance due to the number of cyclic reactions is usually much smaller than the number of internal reactions.

## Function `find_cyclic_reactions`

We add a new function `find_cyclic_reactions` which finds all reactions in the model that can be a part of a cycle.
Also for each such reaction we identify if it can have positive and negative flux in a cycle. This is tested by restricting boundary reaction fluxes to zero and optimizing flux through each of the internal reactions.

There are two methods (`method` parameter) that can be called:

- `basic`: a straightforward procedure that iterates over all of the reactions;
- `optimized`: an optimized version inspired by Fast-SNP random weights idea, which discovers many cyclic reactions in one go.

The second method uses less LP programs and usually works at least 2x faster. It is a custom procedure, so we don't have a citation for the algorithm.

## Function `add_loopless`

We introduced new `method` parameter. If `method="fastSNP"` we:

1. Find all cyclic reactions using `find_cyclic_reactions`.
2. Calculate $N_{\text{int}}$ for the cyclic reactions using Fast-SNP nullspace basis construction algorithm, taking model flux bounds-based signs into account. As the result, the constraints are constructed using much smaller and sparse $N_{\text{int}}$ matrix which greatly reduces number of binary variables in the corresponding MILP prolem and improves the speed of FVA.

If `method="original"` then the current SVD-based algorithm is ran on all of the internal reactions.

## Function `flux_variability_analysis`

We made some optimizations for this function if `loopless=True`.

1. We always find all cyclic reactions and their possible directions using `find_cyclic_reactions` function. Reactions which are not cyclic are optimized using the basic FVA mode—their extreme values are guaranteed to be achievable without using cycle fluxes. This greatly improves the performance of the function even when using the CycleFreeFlux method.
2. We added a new `add_loopless` regime to this function, which adds loopless constraints (re-using the calculated cyclic reactions and `add_loopless` function) to solve loopless FVA for the cyclic reactions. In this regime the exact FVA bounds are calculated (unlike for the CycleFreeFlux method).

# Performance

## FVA quick example

For the quick demonstration of the performance improvement we assembled the following script, which solves FVA for a single reaction with the original and new Fast-SNP loopless constraints.   


```python
import time

from cobra.io import load_model
from cobra.flux_analysis.loopless import add_loopless


for model_name, reaction in [
    ('iIT341', 'ACKr'),
    ('iAF692', 'MDHy'),
    ('iNJ661', 'NADTRHD_copy1'),
]:
    print(f'Working with model {model_name}...')

    for method in ['original', 'fastSNP']:
        model = load_model(model_name)

        print(f'Finding loopless FVA bounds for reaction {reaction} using {method} method...')

        start_time = time.time()
        add_loopless(model, method=method)
        print(f'Loopless constraints added in {time.time() - start_time:.2f} seconds.')
        
        bounds = {}
        start_time = time.time()
        for direction in ['min', 'max']:
            rxn = model.reactions.get_by_id(reaction)
            model.solver.objective.set_linear_coefficients(
                {rxn.forward_variable: 1, rxn.reverse_variable: -1}
            )
            model.solver.objective.direction = direction
            
            bounds[direction] = model.slim_optimize()
        
        print(f'FVA bounds calculated in {time.time() - start_time:.2f} seconds.')
        print(f'Loopless FVA bounds for {reaction} ({method}): {bounds}')
```

Here are the example run times for the tested model/reaction pairs (CPLEX solver was used for MILP):

- Model `iIT341`, reaction `ACKr`: $0.86 \to 0.09$, $9.6\times$ speed-up.
- Model `iAF692`, reaction `MDHy`: $1.35 \to 0.11$, $12.3\times$ speed-up.
- Model `iNJ661`, reaction `NADTRHD_copy1`: $120.61 \to 0.93$, $129\times$ speed-up.

## The fastest complete loopless FVA

The most efficient way to calculate loopless FVA for all of the reactions is to directly call `flux_variability_analysis` function, without using explicit `add_loopless`:

```python
model = load_model(model_name)
flux_variability_analysis(model, loopless=True, params_add_loopless={})
```

# Discussion points

There are several points regarding the API we wanted to highlight for discussion:

1. As was mentioned `flux_variability_analysis(model, loopless=True, params_add_loopless={})` is the most efficient way to calculate loopless FVA. The function `flux_variability_analysis` identifies which method (`add_loopless`-based or CycleFreeFlux) will be used based on the `params_add_loopless` presence. This form enables backward-compatibility, but is a bit clunky. A better way could be to make `loopless` parameter deprecated and replace it with a new string-based `method` parameter to control the behavior, with the corresponding backward compatibility-handling procedure that sets `method="CycleFreeFlux"` if `loopless=True` is present.
2. In `add_loopless` function the original $N_{\text{int}}$ construction algorithm can also benefit from being run only for the cyclic reactions. We could create another option `use_cyclic=True` to enable that, however we decided not to implement it. Our thinking is that `method=original` is provided for the reproducibility of the previous behavior, but ultimately shouldn't be used: the Fast-SNP algorithm should always provide a better performance. 
3. Conversely, `flux_variability_analysis(loopless=True)` can still be ran when the full loopless FVA is not feasible. Thus we decided to implement running CycleFreeFlux only for the cyclic reactions, which significantly improves the performance. This changes the behavior, but should produce the same results as before.


We would be happy to hear your feedback and are ready to implement any additional changes to API/docs/tests/etc that are needed for this PR to be merged.